### PR TITLE
feat: add getSummaryValues API (close #195, #240)

### DIFF
--- a/src/js/grid.js
+++ b/src/js/grid.js
@@ -923,11 +923,43 @@ var Grid = View.extend(/** @lends Grid.prototype */{
     /**
      * Sets the HTML string of given column summary.
      * The type of content is the same as the options.summary.columnContent of the constructor.
-     * @param {string} columnName - columnName
-     * @param {string|object} content - HTML string or options object. 
+     * @param {string} columnName - column name
+     * @param {string|object} content - HTML string or options object.
      */
     setSummaryColumnContent: function(columnName, content) {
         this.modelManager.summaryModel.setColumnContent(columnName, content, true);
+    },
+
+    /**
+     * Returns the values of given column summary.
+     * If the column name is not specified, all values of available columns are returned.
+     * The shape of returning object looks like the example below.
+     * @param {string} [columnName] - column name
+     * @returns {Object}
+     * @example
+     * {
+     *    column1: {
+     *        sum: 1000,
+     *        avg: 200,
+     *        max: 300,
+     *        min: 50,
+     *        cnt: 5
+     *    },
+     *    column2: {
+     *        sum: 2000,
+     *        avg: 300,
+     *        max: 600,
+     *        min: 80,
+     *        cnt: 5
+     *    }
+     * }
+     */
+    getSummaryValues: function(columnName) {
+        if (this.modelManager.summaryModel) {
+            return this.modelManager.summaryModel.getValues(columnName);
+        }
+
+        return null;
     },
 
     /**

--- a/src/js/model/summary.js
+++ b/src/js/model/summary.js
@@ -5,6 +5,7 @@
 
 'use strict';
 
+var $ = require('jquery');
 var _ = require('underscore');
 var snippet = require('tui-code-snippet');
 
@@ -233,6 +234,20 @@ var Summary = Model.extend(/** @lends module:model/summary.prototype */{
         value = snippet.pick(valueMap, summaryType);
 
         return _.isUndefined(value) ? null : value;
+    },
+
+    /**
+     * Returns the summary value of given column.
+     * If the column name is not specified, all values of available columns are returned.
+     * @param {string} [columnName] - column name
+     * @returns {Object}
+     */
+    getValues: function(columnName) {
+        if (columnName) {
+            return $.extend({}, this.columnSummaryMap[columnName]);
+        }
+
+        return $.extend(true, {}, this.columnSummaryMap);
     },
 
     /**

--- a/test/unit/js/model/summary.spec.js
+++ b/test/unit/js/model/summary.spec.js
@@ -363,21 +363,31 @@ describe('model/summary', function() {
     });
 
     describe('getValues(): ', function() {
-        var data = [
-            {c1: 1, c2: 2},
-            {c1: 2, c2: 4},
-            {c1: 3, c2: 6}
-        ];
+        var summary;
 
-        it('If columnName is specified, returns summary value of the column', () => {
-            var summary = create(data, {
-                c1: {template: () => {}},
-                c2: {template: () => {}}
+        beforeEach(function() {
+            summary = create([
+                {
+                    c1: 1,
+                    c2: 2
+                },
+                {
+                    c1: 2,
+                    c2: 4
+                },
+                {
+                    c1: 3,
+                    c2: 6
+                }
+            ], {
+                c1: {template: function() {}},
+                c2: {template: function() {}}
             });
 
-            var values = summary.getValues('c1');
+        });
 
-            expect(values).toEqual({
+        it('If columnName is specified, returns summary value of the column', function() {
+            expect(summary.getValues('c1')).toEqual({
                 sum: 6,
                 min: 1,
                 max: 3,
@@ -386,15 +396,8 @@ describe('model/summary', function() {
             });
         });
 
-        it('If columnName is not specified, returns all summary values', () => {
-            var summary = create(data, {
-                c1: {template: () => {}},
-                c2: {template: () => {}}
-            });
-
-            var values = summary.getValues();
-
-            expect(values).toEqual({
+        it('If columnName is not specified, returns all summary values', function() {
+            expect(summary.getValues()).toEqual({
                 c1: {
                     sum: 6,
                     min: 1,

--- a/test/unit/js/model/summary.spec.js
+++ b/test/unit/js/model/summary.spec.js
@@ -361,4 +361,55 @@ describe('model/summary', function() {
             });
         });
     });
+
+    describe('getValues(): ', function() {
+        var data = [
+            {c1: 1, c2: 2},
+            {c1: 2, c2: 4},
+            {c1: 3, c2: 6}
+        ];
+
+        it('If columnName is specified, returns summary value of the column', () => {
+            var summary = create(data, {
+                c1: {template: () => {}},
+                c2: {template: () => {}}
+            });
+
+            var values = summary.getValues('c1');
+
+            expect(values).toEqual({
+                sum: 6,
+                min: 1,
+                max: 3,
+                avg: 2,
+                cnt: 3
+            });
+        });
+
+        it('If columnName is not specified, returns all summary values', () => {
+            var summary = create(data, {
+                c1: {template: () => {}},
+                c2: {template: () => {}}
+            });
+
+            var values = summary.getValues();
+
+            expect(values).toEqual({
+                c1: {
+                    sum: 6,
+                    min: 1,
+                    max: 3,
+                    avg: 2,
+                    cnt: 3
+                },
+                c2: {
+                    sum: 12,
+                    min: 2,
+                    max: 6,
+                    avg: 4,
+                    cnt: 3
+                }
+            });
+        });
+    });
 });


### PR DESCRIPTION
### Please check if the PR fulfills these requirements
- [x] It's submitted to right branch according to our branching model
- [x] It's right issue type on title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has description for the breaking change

### Description
Add `getSummaryValues()` method
(works only when the summary option exists)

#### Usage 1: with `columnName`
```js
const summaryC1 = grid.getSummaryValues('c1');
console.log(summaryC1);
/*
{
  sum: 1000,
  avg: 200,
  max: 300,
  min: 50,
  cnt: 5
}
*/
```

#### Usage 2 : without `columnName`
```js
const summaryAll = grid.getSummaryValues();
console.log(summaryAll);
/*
{
  c1: {
    sum: 1000,
    avg: 200,
    max: 300,
    min: 50,
    cnt: 5
  },
  c2: {
    sum: 2000,
    avg: 300,
    max: 600,
    min: 80,
    cnt: 5
  }
}
*/
```
---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
